### PR TITLE
fix: corrections de bugs et conformité CROUStillant

### DIFF
--- a/src/features/About/AboutScreen.js
+++ b/src/features/About/AboutScreen.js
@@ -158,7 +158,13 @@ class AboutScreen extends React.Component {
                                 • API CROUStillant
                             </Text>
                             <Text style={{ fontSize: tokens.fontSize.sm, color: theme.fontSecondary, lineHeight: 20, marginLeft: tokens.space.sm }}>
-                                {Translator.get('CROUSTILLANT_DESC')}
+                                {Translator.get('CROUSTILLANT_DESC')}{' '}
+                                <Text
+                                    style={{ color: theme.primary, textDecorationLine: 'underline' }}
+                                    onPress={() => Linking.openURL(URL.CROUSTILLANT_WEBSITE)}
+                                >
+                                    CROUStillant.menu
+                                </Text>
                             </Text>
                         </View>
                     </Section>

--- a/src/features/Crous/CrousMenuScreen.tsx
+++ b/src/features/Crous/CrousMenuScreen.tsx
@@ -18,6 +18,14 @@ export default function CrousMenuScreen({ route, navigation }: any) {
     const [loading, setLoading] = useState(true);
     const [selectedIndex, setSelectedIndex] = useState(0);
     const flatListRef = useRef<FlatList>(null);
+    const mountedRef = useRef(true);
+    const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(() => {
+        return () => {
+            mountedRef.current = false;
+            if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+        };
+    }, []);
 
     useEffect(() => {
         navigation.setOptions({
@@ -37,19 +45,21 @@ export default function CrousMenuScreen({ route, navigation }: any) {
 
     useEffect(() => {
         if (menus.length > 0 && flatListRef.current) {
-            setTimeout(() => {
+            const timerId = setTimeout(() => {
                 flatListRef.current?.scrollToIndex({
                     index: selectedIndex,
                     animated: true,
                     viewPosition: 0.5
                 });
             }, 100);
+            return () => clearTimeout(timerId);
         }
     }, [selectedIndex, menus])
 
     const loadMenu = async () => {
         setLoading(true);
         const data = await CrousService.fetchRestaurantMenu(restaurantId);
+        if (!mountedRef.current) return;
         setMenus(data);
         setLoading(false);
     };
@@ -209,7 +219,7 @@ export default function CrousMenuScreen({ route, navigation }: any) {
                     keyExtractor={(item) => item.date}
                     contentContainerStyle={{ paddingHorizontal: tokens.space.sm }}
                     onScrollToIndexFailed={(info) => {
-                        setTimeout(() => {
+                        scrollTimeoutRef.current = setTimeout(() => {
                             flatListRef.current?.scrollToIndex({ index: info.index, animated: true, viewPosition: 0.5 });
                         }, 500);
                     }}

--- a/src/features/Crous/CrousScreen.tsx
+++ b/src/features/Crous/CrousScreen.tsx
@@ -26,6 +26,8 @@ function CrousScreen({ navigation, onAnimatedScroll, headerPadding }: any) {
     const [locationError, setLocationError] = useState(false);
 
     const [favorites, setFavorites] = useState<string[]>([]);
+    const mountedRef = useRef(true);
+    useEffect(() => { return () => { mountedRef.current = false; }; }, []);
 
     /* * On recharge les favoris a chaque fois que l'ecran est au premier plan.
      * C'est indispensable pour synchroniser l'etat si l'utilisateur a clique 
@@ -97,13 +99,14 @@ function CrousScreen({ navigation, onAnimatedScroll, headerPadding }: any) {
                     userLon = location.coords.longitude;
                 }
             } else {
-                setLocationError(true);
+                if (mountedRef.current) setLocationError(true);
             }
         } catch (e) {
-            setLocationError(true);
+            if (mountedRef.current) setLocationError(true);
         }
 
         const data = await CrousService.fetchRestaurantsBordeaux(userLat, userLon);
+        if (!mountedRef.current) return;
         setRestaurants(data);
         setLoading(false);
     };

--- a/src/features/Crous/CrousService.ts
+++ b/src/features/Crous/CrousService.ts
@@ -65,7 +65,7 @@ class CrousServiceManager {
             const jsonResponse = await response.json();
             if (!jsonResponse.data) return [];
 
-            let restaurants: CrousRestaurant[] = jsonResponse.data.map((resto: any) => {
+            let restaurants: CrousRestaurant[] = jsonResponse.data.filter((resto: any) => resto.type?.code !== 4).map((resto: any) => {
                 let distance = undefined;
                 if (userLat !== undefined && userLon !== undefined) {
                     distance = getDistanceInKm(userLat, userLon, resto.latitude, resto.longitude);

--- a/src/features/Home/HomeScreen.js
+++ b/src/features/Home/HomeScreen.js
@@ -223,7 +223,9 @@ class HomeScreen extends React.Component {
 
 				this.setState({ cacheDate: null });
 				list = groupList.map((e) => ({ name: e }));
-				AsyncStorage.setItem('groups', JSON.stringify({ list, date: moment() }));
+				AsyncStorage.setItem('groups', JSON.stringify({ list, date: moment() })).catch((e) =>
+					console.warn('Échec de la mise en cache des groupes :', e)
+				);
 			} catch (error) {
 				if (error.response) {
 					Toast.show(Translator.get('ERROR_WITH_CODE'), {

--- a/src/features/Library/LibraryDetailsScreen.tsx
+++ b/src/features/Library/LibraryDetailsScreen.tsx
@@ -20,6 +20,14 @@ export default function LibraryDetailsScreen({ route, navigation }: any) {
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [weekOffset, setWeekOffset] = useState(0); // 0 = semaine en cours, -1 = semaine dernière, 1 = semaine pro
     const flatListRef = useRef<FlatList>(null);
+    const mountedRef = useRef(true);
+    const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(() => {
+        return () => {
+            mountedRef.current = false;
+            if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+        };
+    }, []);
     
 
     useEffect(() => {
@@ -40,8 +48,9 @@ export default function LibraryDetailsScreen({ route, navigation }: any) {
     const loadTimetable = async (offset: number) => {
         setLoading(true);
         const data = await LibraryService.fetchLibraryTimetable(library.slug, offset);
+        if (!mountedRef.current) return;
         setTimetable(data);
-        
+
         // Si on est sur la semaine actuelle, on sélectionne aujourd'hui. Sinon, on sélectionne le lundi (index 0).
         if (offset === 0) {
             const todayIndex = data.findIndex(entry => entry.isToday);
@@ -49,7 +58,7 @@ export default function LibraryDetailsScreen({ route, navigation }: any) {
         } else {
             setSelectedIndex(0);
         }
-        
+
         setLoading(false);
     };
 
@@ -69,13 +78,14 @@ export default function LibraryDetailsScreen({ route, navigation }: any) {
 
     useEffect(() => {
         if (timetable.length > 0 && flatListRef.current) {
-            setTimeout(() => {
+            const timerId = setTimeout(() => {
                 flatListRef.current?.scrollToIndex({
                     index: selectedIndex,
                     animated: true,
                     viewPosition: 0.5
                 });
             }, 100);
+            return () => clearTimeout(timerId);
         }
     }, [selectedIndex, timetable]);
 
@@ -154,7 +164,7 @@ export default function LibraryDetailsScreen({ route, navigation }: any) {
                     keyExtractor={(item) => item.day}
                     contentContainerStyle={{ paddingHorizontal: tokens.space.sm }}
                     onScrollToIndexFailed={(info) => {
-                        setTimeout(() => {
+                        scrollTimeoutRef.current = setTimeout(() => {
                             flatListRef.current?.scrollToIndex({ index: info.index, animated: true, viewPosition: 0.5 });
                         }, 500);
                     }}

--- a/src/features/Library/LibraryScreen.tsx
+++ b/src/features/Library/LibraryScreen.tsx
@@ -28,6 +28,8 @@ function LibraryScreen({ navigation, onAnimatedScroll, headerPadding }: any) {
     const [locationError, setLocationError] = useState(false);
 
     const [favorites, setFavorites] = useState<string[]>([]);
+    const mountedRef = useRef(true);
+    useEffect(() => { return () => { mountedRef.current = false; }; }, []);
 
     useFocusEffect(
         useCallback(() => {
@@ -90,7 +92,7 @@ function LibraryScreen({ navigation, onAnimatedScroll, headerPadding }: any) {
                     userLng = location.coords.longitude;
                 }
             } else {
-                setLocationError(true);
+                if (mountedRef.current) setLocationError(true);
             }
 
             // Fallback sur le campus de Talence si le GPS de l'émulateur échoue
@@ -100,6 +102,7 @@ function LibraryScreen({ navigation, onAnimatedScroll, headerPadding }: any) {
             }
 
             const fetchedLibs = await LibraryService.fetchNearbyLibraries(userLat, userLng);
+            if (!mountedRef.current) return;
 
             const nearbyLibs = fetchedLibs;
             setLibraries(nearbyLibs);
@@ -110,6 +113,8 @@ function LibraryScreen({ navigation, onAnimatedScroll, headerPadding }: any) {
             });
 
             const results = await Promise.all(affluencesPromises);
+            if (!mountedRef.current) return;
+
             const newAffluences: Record<string, AffluencesData> = {};
             results.forEach(res => {
                 if (res.data) newAffluences[res.id] = res.data;
@@ -119,7 +124,7 @@ function LibraryScreen({ navigation, onAnimatedScroll, headerPadding }: any) {
         } catch (error) {
             console.error("Erreur critique dans loadLibraries:", error);
         } finally {
-            setLoading(false);
+            if (mountedRef.current) setLoading(false);
         }
     };
 

--- a/src/features/Schedule/ScheduleList.js
+++ b/src/features/Schedule/ScheduleList.js
@@ -288,7 +288,7 @@ export class ScheduleList extends React.Component {
 
                 let schedule;
                 if (mode === 'day') {
-                    schedule = this.computeScheduleDay(fetchedData, this.state.groupName === this.state.groupName);
+                    schedule = this.computeScheduleDay(fetchedData, Array.isArray(this.state.groupName));
                 } else {
                     schedule = fetchedData;
                 }
@@ -400,7 +400,7 @@ export class ScheduleList extends React.Component {
                 />
             );
         } else if (this.state.schedule instanceof Array && mode === 'week') {
-            const isFavorite = this.state.groupName === this.state.groupName;
+            const isFavorite = Array.isArray(this.state.groupName);
             const targetYear = this.state.target.year || moment().year();
             const targetWeek = this.state.target.week;
 

--- a/src/features/Schedule/ScheduleScreen.js
+++ b/src/features/Schedule/ScheduleScreen.js
@@ -33,7 +33,7 @@ export default function ScheduleScreen(props) {
                 headerRight: helper.headerRight
             });
         }
-    }, [groupName, props.navigation, context.themeName]);
+    }, [groupName, props.navigation, context.themeName, props.route?.params?.animatedReady]);
     
     return <DayView {...props} groupName={groupName} />;
 }

--- a/src/features/Settings/SettingsScreen.js
+++ b/src/features/Settings/SettingsScreen.js
@@ -48,9 +48,6 @@ class Settings extends React.Component {
             selectedCalendar: SettingsManager.getSyncCalendar(),
         };
 
-        SettingsManager.on('filter', () => {
-            this.setState({ filterList: SettingsManager.getFilters() });
-        });
     }
 
     setCalendar = (calendar) => {
@@ -130,10 +127,12 @@ class Settings extends React.Component {
             this.toggleCalendarSync();
         }
         SettingsManager.on('isSynchronizingCalendar', this.setIsSynchronizingCalendar);
+        SettingsManager.on('filter', this.refreshFiltersList);
     };
 
     componentWillUnmount = () => {
         SettingsManager.unsubscribe('isSynchronizingCalendar', this.setIsSynchronizingCalendar);
+        SettingsManager.unsubscribe('filter', this.refreshFiltersList);
     };
 
     render() {

--- a/src/shared/i18n/en.js
+++ b/src/shared/i18n/en.js
@@ -140,7 +140,7 @@ export default {
 	API_AFFLUENCES: '• API Affluences',
 	AFFLUENCES_DESC: 'Real-time schedules and attendance for libraries (BU).',
 	API_CROUSTILLANT: '• API CROUStillant',
-	CROUSTILLANT_DESC: 'Daily menus and images for university restaurants.',
+	CROUSTILLANT_DESC: 'Daily menus and images for university restaurants provided by',
 	NO_MENU_PUBLISHED: 'No menu published for this restaurant currently.',
     NOT_SPECIFIED: 'Not specified',
     NO_DISH_INFO: 'No dish information for this day.',

--- a/src/shared/i18n/es.js
+++ b/src/shared/i18n/es.js
@@ -144,7 +144,7 @@ export default {
 	API_AFFLUENCES: '• API Affluences',
 	AFFLUENCES_DESC: 'Horarios y afluencia en tiempo real de las bibliotecas (BU).',
 	API_CROUSTILLANT: '• API CROUStillant',
-	CROUSTILLANT_DESC: 'Menús diarios e imágenes de los restaurantes universitarios.',
+	CROUSTILLANT_DESC: 'Menús diarios e imágenes de los restaurantes universitarios proporcionado por',
 	NO_MENU_PUBLISHED: 'No hay menú publicado para este restaurante actualmente.',
     NOT_SPECIFIED: 'No especificado',
     NO_DISH_INFO: 'No hay información de platos para este día.',

--- a/src/shared/i18n/fr.js
+++ b/src/shared/i18n/fr.js
@@ -142,7 +142,7 @@ export default {
 	API_AFFLUENCES: '• API Affluences',
 	AFFLUENCES_DESC: 'Horaires et affluence en temps réel des bibliothèques (BU).',
 	API_CROUSTILLANT: '• API CROUStillant',
-	CROUSTILLANT_DESC: 'Menus quotidiens et images des restaurants universitaires.',
+	CROUSTILLANT_DESC: 'Menus quotidiens et images des restaurants universitaires fournis par',
 	NO_MENU_PUBLISHED: 'Aucun menu publié pour ce restaurant actuellement.',
     NOT_SPECIFIED: 'Non précisé',
     NO_DISH_INFO: 'Aucun plat renseigné pour cette journée.',

--- a/src/shared/navigation/rootContainer.jsx
+++ b/src/shared/navigation/rootContainer.jsx
@@ -20,15 +20,28 @@ export default (props) => {
 	}
 
 	useEffect(() => {
-		SettingsManager.on('theme', (newTheme) => setThemeName(newTheme));
-		SettingsManager.on('favoriteGroups', (newGroups) => setFavoriteGroups(newGroups));
-		SettingsManager.on('firstload', (newFistLoad) => setFirstLoad(newFistLoad));
-		SettingsManager.on('language', (newLang) => setLanguage(newLang));
-		SettingsManager.on('filter', (newFilter) => setFilters(newFilter));
+		const onTheme = (newTheme) => setThemeName(newTheme);
+		const onFavoriteGroups = (newGroups) => setFavoriteGroups(newGroups);
+		const onFirstLoad = (newFirstLoad) => setFirstLoad(newFirstLoad);
+		const onLanguage = (newLang) => setLanguage(newLang);
+		const onFilter = (newFilter) => setFilters(newFilter);
+
+		SettingsManager.on('theme', onTheme);
+		SettingsManager.on('favoriteGroups', onFavoriteGroups);
+		SettingsManager.on('firstload', onFirstLoad);
+		SettingsManager.on('language', onLanguage);
+		SettingsManager.on('filter', onFilter);
 
 		const eventSubscription = AppState.addEventListener('change', reloadData);
 
-		return () => eventSubscription.remove();
+		return () => {
+			SettingsManager.unsubscribe('theme', onTheme);
+			SettingsManager.unsubscribe('favoriteGroups', onFavoriteGroups);
+			SettingsManager.unsubscribe('firstload', onFirstLoad);
+			SettingsManager.unsubscribe('language', onLanguage);
+			SettingsManager.unsubscribe('filter', onFilter);
+			eventSubscription.remove();
+		};
 	}, []);
 
 	const theme = Style.Theme[themeName];

--- a/src/shared/services/DataService.js
+++ b/src/shared/services/DataService.js
@@ -18,6 +18,7 @@ export const URL = {
     VERSION_STORE: 'https://raw.githubusercontent.com/KAE-Lab/UKit/master/VERSION',
     GOOGLE_APP: 'https://play.google.com/store/apps/details?id=com.bordeaux1.emplois',
     APPLE_APP: 'https://apps.apple.com/fr/app/ukit-bordeaux/id1394708917',
+    CROUSTILLANT_WEBSITE: 'https://croustillant.menu',
 };
 
 export const WebApiURL = {


### PR DESCRIPTION
## Résumé

- **Header animé cassé** sur l'écran planning : `animatedReady` ajouté aux dépendances du `useLayoutEffect` pour que le scroll soit correctement connecté après l'initialisation du HOC
- **Filtres UE** appliqués à tous les groupes au lieu de "Mon Planning" uniquement (comparaison `x === x` toujours vraie)
- **Fuites mémoire** : listeners `SettingsManager` non désabonnés à l'unmount dans `rootContainer` et `SettingsScreen`
- **setState après unmount** dans `CrousScreen`, `LibraryScreen`, `LibraryDetailsScreen` et `CrousMenuScreen`
- **setTimeout sans cleanup** dans `LibraryDetailsScreen` et `CrousMenuScreen`
- **AsyncStorage** sans `.catch()` dans `HomeScreen`
- **Restaurants agréés** (hôpitaux, lycées) exclus de la liste CROUS via le champ `type.code` de l'API
- **Crédits CROUStillant** mis en conformité avec les conditions d'utilisation officielles (mention + lien vers croustillant.menu)
